### PR TITLE
resolves #1, remove boundary metadata from multipart upload

### DIFF
--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -45,12 +45,12 @@ describe('App', () => {
   describe('GET /files/:id/download', () => {
     it('should download specified file', async () => {
       const allFilesResponse = await server.get('/files');
-      const fileId = allFilesResponse.body[0].id;
+      const fileId = allFilesResponse.body[allFilesResponse.body.length - 1].id;
       const response = await server.get(`/files/${fileId}/download`)
       expect(response.statusCode).toEqual(200);
-      // const responseFile = Buffer.from(response.body);
-      // const sampleFile = readFileSync(join(__dirname, './sampleFile1KB.tgz'))
-      // expect(responseFile.equals(sampleFile)).toEqual(true);
+      const responseFile = Buffer.from(response.body);
+      const sampleFile = readFileSync(join(__dirname, './sampleFile1KB.tgz'))
+      expect(responseFile.equals(sampleFile)).toEqual(true);
     });
   });
   

--- a/src/app.ts
+++ b/src/app.ts
@@ -76,7 +76,9 @@ app.post('/files', (req, res) => {
         error: new Error('Wrong content type')
       })
     }
+    const boundary = contentType.split(';')[1].split('=')[1].trim();
     uploadFile(req, {
+      boundary,
       contentLength,
       onStarted: (fileMeta) => res.json(fileMeta),
       onError: (err) => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,8 +30,8 @@ app.get('/files/:id/download', async (req, res) => {
     const { id } = req.params;
     const file = await getFileById(id);
     if (file) {
-        const { fileName } = file;
-        const filePath = join(uploadDir, id + '_' + fileName);
+        const { fileName, size } = file;
+        const filePath = join(uploadDir, id + '_' + size + '_' + fileName);
         const readFileStream = createReadStream(filePath);
         res.setHeader('Content-Type', 'application/octet-stream');
         res.setHeader('Content-Disposition', 'attachment; filename=' + fileName);
@@ -50,8 +50,8 @@ app.delete('/files/:id', async (req, res) => {
     const { id } = req.params;
     const file = await getFileById(id);
     if (file) {
-        const { fileName } = file;
-        const filePath = join(uploadDir, id + '_' + fileName);
+        const { fileName, size } = file;
+        const filePath = join(uploadDir, id + '_' + size + '_' + fileName);
         deleteFileById(req.params.id)
         .then(() => fsp.unlink(filePath))
         .then(() => res.json({ message: `Successfully deleted: ${fileName}` }))

--- a/src/services/file.ts
+++ b/src/services/file.ts
@@ -56,17 +56,16 @@ const removeBoundaryData = (chunk: Buffer, boundary: string): Buffer => {
 
 const isValidFileType = (fileName: string): boolean => /(\.tgz)$/.test(fileName);
 
-const processFirstChunk = async (contentLength: number, fileName: string, existing: any = {}) => {
+const processFirstChunk = async (contentLength: number, fileName: string) => {
   const fileMeta = await upsertFile({
-   ...existing,
-   fileName,
-   uploadStatus: 'In progress',
-   size: contentLength,
-   progress: existing.progress || '0%'
- });
- const fileId = fileMeta.id;
- const fileWriteStream = createWriteStream(join(uploadDir, fileId + '_' + contentLength + '_' + fileMeta.fileName));
- return { fileMeta, fileWriteStream };
+    fileName,
+    uploadStatus: 'In progress',
+    size: contentLength,
+    progress: '0%'
+  });
+  const fileId = fileMeta.id;
+  const fileWriteStream = createWriteStream(join(uploadDir, fileId + '_' + contentLength + '_' + fileMeta.fileName));
+  return { fileMeta, fileWriteStream };
 }
 
 interface NonFirstChunkInput {
@@ -134,7 +133,7 @@ export const uploadFile = (
         return;
       } 
       if (fileName) {
-        fileCtx = await processFirstChunk(contentLength, fileName, fileCtx?.fileMeta);
+        fileCtx = await processFirstChunk(contentLength, fileName);
         onStarted(fileCtx.fileMeta);
       }
       dataLength += chunk?.length ?? 0;

--- a/src/services/file.ts
+++ b/src/services/file.ts
@@ -30,27 +30,54 @@ const getFileName = (chunk: Buffer) => {
   }
 };
 
+
+const removeBoundaryData = (chunk: Buffer, boundary: string): Buffer => {
+  let cleanedChunk = chunk;
+  const stringRep = chunk.toString('latin1');
+  const boundaryRegx = new RegExp(`(\r\n)?-*${boundary}-*(\r\n)?`);
+  const boundaryMatch = stringRep.match(boundaryRegx);
+  if (boundaryMatch) {
+    const boundaryStartIdx = boundaryMatch.index;
+    const boundaryEndIdx = boundaryStartIdx + boundaryMatch[0]?.length;
+    const endOfHeaderMeta = stringRep.indexOf('\r\n\r\n') + 4; //4 being length
+    if (boundaryStartIdx === 0 && endOfHeaderMeta > 3) {
+      cleanedChunk = cleanedChunk.slice(endOfHeaderMeta);
+    } else if (boundaryStartIdx > -1) {
+      const startChunk = cleanedChunk.slice(0, boundaryStartIdx);
+      const endChunk = cleanedChunk.slice(boundaryEndIdx);
+      cleanedChunk = Buffer.concat([startChunk, endChunk]);
+    };
+    if (cleanedChunk.toString('latin1').match(boundaryRegx)) {
+      return removeBoundaryData(cleanedChunk, boundary);
+    };
+  };
+  return cleanedChunk;
+};
+
 const isValidFileType = (fileName: string): boolean => /(\.tgz)$/.test(fileName);
 
-const processFirstChunk = async (contentLength: number, fileName: string) => {
+const processFirstChunk = async (contentLength: number, fileName: string, existing: any = {}) => {
   const fileMeta = await upsertFile({
-    fileName,
-    uploadStatus: 'In progress',
-    size: contentLength,
-    progress: '0%'
-  });
-  const fileId = fileMeta.id;
-  const fileStream = createWriteStream(join(uploadDir, fileId + '_' + fileMeta.fileName));
-  return { fileMeta, fileStream };
+   ...existing,
+   fileName,
+   uploadStatus: 'In progress',
+   size: contentLength,
+   progress: existing.progress || '0%'
+ });
+ const fileId = fileMeta.id;
+ const fileWriteStream = createWriteStream(join(uploadDir, fileId + '_' + contentLength + '_' + fileMeta.fileName));
+ return { fileMeta, fileWriteStream };
 }
 
 interface NonFirstChunkInput {
+  boundary: string;
   chunk: Buffer;
   source: IncomingMessage;
   dataLength: number; 
   contentLength: number;
 }
 const processNonFirstChunk = async ({
+    boundary,
     chunk,
     source,
     dataLength, 
@@ -59,12 +86,15 @@ const processNonFirstChunk = async ({
   { fileWriteStream, fileMeta }: FileContext
 ) => {
   if (fileWriteStream && fileMeta) {
-    fileWriteStream.write(chunk, (err: Error) => {
-      if (!err) return
-      source.emit('error', new Error('Failed to save file: ' + fileMeta.fileName))
-      // clean up
-      deleteFileById(fileMeta.id);
-    });
+    fileWriteStream.write(
+      removeBoundaryData(chunk, boundary),
+      (err: Error) => {
+        if (!err) return
+        source.emit('error', new Error('Failed to save file: ' + fileMeta.fileName))
+        // clean up
+        deleteFileById(fileMeta.id);
+      }
+    );
   };
 
   updateFileMeta(
@@ -74,6 +104,7 @@ const processNonFirstChunk = async ({
 }
 
 interface UploadFileConfig {
+  boundary: string;
   contentLength: number;
   onStarted: (file: FileMeta) => any;
   onError: (err: Error) => any;
@@ -91,6 +122,7 @@ export const uploadFile = (
     onStarted,
     onError,
     contentLength,
+    boundary,
   }: UploadFileConfig
 ) => {
   let dataLength: number = 0;
@@ -102,11 +134,17 @@ export const uploadFile = (
         return;
       } 
       if (fileName) {
-        fileCtx = await processFirstChunk(contentLength, fileName);
+        fileCtx = await processFirstChunk(contentLength, fileName, fileCtx?.fileMeta);
         onStarted(fileCtx.fileMeta);
       }
       dataLength += chunk?.length ?? 0;
-      processNonFirstChunk({ chunk, source, dataLength, contentLength }, fileCtx);
+      processNonFirstChunk({
+        boundary,
+        chunk,
+        source,
+        dataLength,
+        contentLength
+      }, fileCtx);
       // onProgress?
     });
 


### PR DESCRIPTION
This PR will:
- remove content boundary metadata from streamed chunks. The saved file included these content boundary details and thereby corrupting the uploaded file.
- enable test that should have caught this
- update code accordingly